### PR TITLE
fix: set access to public for npm publish

### DIFF
--- a/workflow-templates/on-push-publish-to-npm.yml
+++ b/workflow-templates/on-push-publish-to-npm.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          access: 'public'


### PR DESCRIPTION
By default, access is set to 'restricted' for scoped npm packages. See [input parameters](https://github.com/JS-DevTools/npm-publish#input-parameters)
This is problematic for new repos getting published which needs someone with npm admin access to the scope to flip the access. This person may not be readily available.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
