### PR TITLE
🔒  Issue #3: version-bump-publish.yml - does not work with Protected …

### DIFF
--- a/workflow-templates/version-bump-publish.yml
+++ b/workflow-templates/version-bump-publish.yml
@@ -3,22 +3,25 @@ on:
   workflow_dispatch:
     inputs:
       level:
-        description: '<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease'
+        description: "<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease"
         required: true
-        default: 'patch'
+        default: "patch"
       tag:
-        description: 'The tag to publish to.'
+        description: "The tag to publish to."
         required: false
-        default: 'latest'
+        default: "latest"
 jobs:
   checkout:
     name: checkout
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+        with:
+          token: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
+      - name: Configure CI Git User
+        run: |
+          git config user.name adobe-bot
+          git config user.email grp-opensourceoffice@adobe.com
       - uses: actions/setup-node@v1
         with:
           node-version: 10
@@ -34,4 +37,4 @@ jobs:
         with:
           token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           tag: ${{ github.event.inputs.tag }}
-          access: 'public'
+          access: "public"


### PR DESCRIPTION
…Branches with status checks

<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses the adobe-bot credentials so bump and publish can run on protected branches.

## Related Issue

#3 

## Motivation and Context

Supports repos that protect their branches and also want to be able to publish via github actions.

## How Has This Been Tested?

I've test driven it in the jwt-auth repo:

https://github.com/adobe/jwt-auth/commit/72997490401e99acd269a9c79129ba142063a632

and it worked great releasing a 1.0.1.

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
